### PR TITLE
Pmc 22661 ahead of print

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ subprojects {
     apply plugin: 'osgi'
     apply plugin: 'eclipse'
     
-    version = '0.6'
+    version = '0.7-SNAPSHOT'
     group = 'de.undercouch'
     sourceCompatibility = '1.6'
     targetCompatibility = '1.6'

--- a/citeproc-java/build.gradle
+++ b/citeproc-java/build.gradle
@@ -12,8 +12,8 @@ apply plugin: 'signing'
 
 import de.undercouch.gradle.tasks.download.Download
 
-ext.citeprocProjectBase = 'https://bitbucket.org/fbennett/citeproc-js/'
-ext.citeprocJsUrlBase = ext.citeprocProjectBase + 'raw/01297da0b8365851689d2c3d0a56e57147de1b67/'
+ext.citeprocProjectBase = 'https://bitbucket.org/klortho/citeproc-js/'
+ext.citeprocJsUrlBase = ext.citeprocProjectBase + 'raw/fe96bd9a2f57c1dad7e6a83534615d9a246d1096/'
 ext.citeprocJsUrl = ext.citeprocJsUrlBase + 'citeproc.js'
 ext.xmldomJsUrl = ext.citeprocJsUrlBase + 'xmldom.js'
 ext.xmle4xJsUrl = ext.citeprocJsUrlBase + 'xmle4x.js'

--- a/citeproc-java/src/main/java/de/undercouch/citeproc/CSL.java
+++ b/citeproc-java/src/main/java/de/undercouch/citeproc/CSL.java
@@ -79,7 +79,7 @@ import de.undercouch.citeproc.script.ScriptRunnerFactory;
  * CSL citeproc = new CSL(new MyItemProvider(), "ieee");
  * citeproc.setOutputFormat("html");</pre></blockquote>
  * 
- * <h4>Ad-hoc usage</h4>
+ * <h3>Ad-hoc usage</h3>
  * 
  * You may also use {@link #makeAdhocBibliography(String, CSLItemData...)} or
  * {@link #makeAdhocBibliography(String, String, CSLItemData...)} to create
@@ -105,7 +105,7 @@ import de.undercouch.citeproc.script.ScriptRunnerFactory;
  * <code>ThreadLocal</code>.</p>
  * 
  * <blockquote><pre>
- * ThreadLocal&lt;CSL> csl = new ThreadLocal&lt;CSL>() {
+ * ThreadLocal&lt;CSL&gt; csl = new ThreadLocal&lt;CSL&gt;() {
  *     &#64;Override
  *     protected CSL initialValue() {
  *         return new CSL(itemDataProvider, style, lang);

--- a/citeproc-java/src/main/java/de/undercouch/citeproc/bibtex/DateParser.java
+++ b/citeproc-java/src/main/java/de/undercouch/citeproc/bibtex/DateParser.java
@@ -55,7 +55,7 @@ public class DateParser {
 	 * whose last four characters are digits.
 	 * @param month the month to parse. May be a number (<code>1-12</code>),
 	 * a short month name (<code>Jan</code> to <code>Dec</code>), or a
-	 * long month name (<code>January</code> to </code>December</code>). This
+	 * long month name (<code>January</code> to <code>December</code>). This
 	 * method is also able to recognize month names in several locales.
 	 * @return the {@link CSLDate} object or null if both, the year and the
 	 * month, could not be parsed
@@ -107,7 +107,7 @@ public class DateParser {
 	 * whose last four characters are digits.
 	 * @param month the month to parse. May be a number (<code>1-12</code>),
 	 * a short month name (<code>Jan</code> to <code>Dec</code>), or a
-	 * long month name (<code>January</code> to </code>December</code>). This
+	 * long month name (<code>January</code> to <code>December</code>). This
 	 * method is also able to recognize month names in several locales.
 	 * @return the {@link CSLDate} object or null if both, the year and the
 	 * month, could not be parsed
@@ -145,7 +145,7 @@ public class DateParser {
 	 * whose last four characters are digits.
 	 * @param month the month to parse. May be a number (<code>1-12</code>),
 	 * a short month name (<code>Jan</code> to <code>Dec</code>), or a
-	 * long month name (<code>January</code> to </code>December</code>). This
+	 * long month name (<code>January</code> to <code>December</code>). This
 	 * method is also able to recognize month names in several locales.
 	 * @return the {@link CSLDate} object or null if both, the year and the
 	 * month, could not be parsed
@@ -250,7 +250,7 @@ public class DateParser {
 	 * Parses the given month string
 	 * @param month the month to parse. May be a number (<code>1-12</code>),
 	 * a short month name (<code>Jan</code> to <code>Dec</code>), or a
-	 * long month name (<code>January</code> to </code>December</code>). This
+	 * long month name (<code>January</code> to <code>December</code>). This
 	 * method is also able to recognize month names in several locales.
 	 * @return the month's number (<code>1-12</code>) or <code>-1</code> if
 	 * the string could not be parsed

--- a/citeproc-java/templates/CSLItemData.json
+++ b/citeproc-java/templates/CSLItemData.json
@@ -96,6 +96,10 @@
         },
         {
             "type": "CSLDate",
+            "name": "epub-date"
+        },
+        {
+            "type": "CSLDate",
             "name": "issued"
         },
         {


### PR DESCRIPTION
This adds support for a new date field, `epub-date`, as described in the xbiblio-devel email thread, [How to encode and process "ahead of print"](http://sourceforge.net/p/xbiblio/mailman/message/34179904/).
