### PR TITLE
Workaround mem leak in V8

### DIFF
--- a/citeproc-java-tool/src/main/java/de/undercouch/citeproc/tool/BibliographyCommand.java
+++ b/citeproc-java-tool/src/main/java/de/undercouch/citeproc/tool/BibliographyCommand.java
@@ -157,28 +157,25 @@ public class BibliographyCommand extends CitationIdsCommand {
 		}
 		
 		//initialize citation processor
-		CSL citeproc;
-		try {
-			citeproc = new CSL(provider, style, locale);
+		try (CSL citeproc = new CSL(provider, style, locale)) {
+			//set output format
+			citeproc.setOutputFormat(format);
+
+			//register citation items
+			String[] citationIdsArr = new String[citationIds.size()];
+			citationIdsArr = citationIds.toArray(citationIdsArr);
+			if (citationIds.isEmpty()) {
+				citationIdsArr = provider.getIds();
+			}
+			citeproc.registerCitationItems(citationIdsArr);
+
+			//generate bibliography
+			doGenerateCSL(citeproc, citationIdsArr, out);
 		} catch (FileNotFoundException e) {
 			error(e.getMessage());
 			return 1;
 		}
-		
-		//set output format
-		citeproc.setOutputFormat(format);
-		
-		//register citation items
-		String[] citationIdsArr = new String[citationIds.size()];
-		citationIdsArr = citationIds.toArray(citationIdsArr);
-		if (citationIds.isEmpty()) {
-			citationIdsArr = provider.getIds();
-		}
-		citeproc.registerCitationItems(citationIdsArr);
-		
-		//generate bibliography
-		doGenerateCSL(citeproc, citationIdsArr, out);
-		
+
 		return 0;
 	}
 	

--- a/citeproc-java/src/main/java/de/undercouch/citeproc/CSL.java
+++ b/citeproc-java/src/main/java/de/undercouch/citeproc/CSL.java
@@ -14,6 +14,7 @@
 
 package de.undercouch.citeproc;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -109,6 +110,18 @@ import de.undercouch.citeproc.script.ScriptRunnerFactory;
  *     .build();
  *     
  * String bibl = CSL.makeAdhocBibliography("ieee", item).makeString();</pre></blockquote>
+ *
+ * <h3>Cleanup</h3>
+ *
+ * <p>Make sure to call {@link #close()} to release all resources associated
+ * with the CSL processor when you're done with it. We recommend using a
+ * try-with-resources statement:</p>
+ *
+ * <blockquote><pre>
+ * try (CSL citeproc = new CSL(new MyItemProvider(), "ieee")) {
+ *     citeproc.setOutputFormat("html");
+ *     ...
+ * }</pre></blockquote>
  * 
  * <h3>Thread-safety</h3>
  * 
@@ -130,7 +143,7 @@ import de.undercouch.citeproc.script.ScriptRunnerFactory;
  * 
  * @author Michel Kraemer
  */
-public class CSL {
+public class CSL implements Closeable {
 	/**
 	 * A thread-local holding a JavaScript runner that can
 	 * be shared amongst multiple instances of this class
@@ -275,12 +288,12 @@ public class CSL {
 			AbbreviationProvider abbreviationProvider, VariableWrapper variableWrapper,
 			String style, String lang, boolean forceLang) throws IOException {
 		runner = getRunner();
-		
+
 		//load style if needed
 		if (!isStyle(style)) {
 			style = loadStyle(style);
 		}
-		
+
 		//initialize engine
 		try {
 			engine = runner.callMethod("makeCsl", Object.class,
@@ -937,11 +950,9 @@ public class CSL {
 	 * could not be loaded
 	 */
 	public static Bibliography makeAdhocBibliography(String style, String outputFormat,
-	                                                 CSLItemData... items) throws IOException {
+			CSLItemData... items) throws IOException {
 		ItemDataProvider provider = new ListItemDataProvider(items);
-		CSL csl = null;
-		try {
-			csl = new CSL(provider, style);
+		try (CSL csl = new CSL(provider, style)) {
 			csl.setOutputFormat(outputFormat);
 
 			String[] ids = new String[items.length];
@@ -951,16 +962,11 @@ public class CSL {
 			csl.registerCitationItems(ids);
 
 			return csl.makeBibliography();
-		} finally {
-			if (csl != null) {
-				csl.release();
-			}
 		}
 	}
 
-	private void release() {
-		if ((engine != null) && com.eclipsesource.v8.V8Object.class.isAssignableFrom(engine.getClass())) {
-			((com.eclipsesource.v8.V8Object)engine).release();
-		}
+	@Override
+	public void close() {
+		runner.release(engine);
 	}
 }

--- a/citeproc-java/src/main/java/de/undercouch/citeproc/CSL.java
+++ b/citeproc-java/src/main/java/de/undercouch/citeproc/CSL.java
@@ -937,17 +937,30 @@ public class CSL {
 	 * could not be loaded
 	 */
 	public static Bibliography makeAdhocBibliography(String style, String outputFormat,
-			CSLItemData... items) throws IOException {
+	                                                 CSLItemData... items) throws IOException {
 		ItemDataProvider provider = new ListItemDataProvider(items);
-		CSL csl = new CSL(provider, style);
-		csl.setOutputFormat(outputFormat);
-		
-		String[] ids = new String[items.length];
-		for (int i = 0; i < items.length; ++i) {
-			ids[i] = items[i].getId();
+		CSL csl = null;
+		try {
+			csl = new CSL(provider, style);
+			csl.setOutputFormat(outputFormat);
+
+			String[] ids = new String[items.length];
+			for (int i = 0; i < items.length; ++i) {
+				ids[i] = items[i].getId();
+			}
+			csl.registerCitationItems(ids);
+
+			return csl.makeBibliography();
+		} finally {
+			if (csl != null) {
+				csl.release();
+			}
 		}
-		csl.registerCitationItems(ids);
-		
-		return csl.makeBibliography();
+	}
+
+	private void release() {
+		if ((engine != null) && com.eclipsesource.v8.V8Object.class.isAssignableFrom(engine.getClass())) {
+			((com.eclipsesource.v8.V8Object)engine).release();
+		}
 	}
 }

--- a/citeproc-java/src/main/java/de/undercouch/citeproc/script/JREScriptRunner.java
+++ b/citeproc-java/src/main/java/de/undercouch/citeproc/script/JREScriptRunner.java
@@ -152,7 +152,19 @@ public class JREScriptRunner extends AbstractScriptRunner {
 		}
 		return result;
 	}
-	
+
+	@Override
+	public void close() {
+		// nothing to do here
+		// runner will be garbage collected
+	}
+
+	@Override
+	public void release(Object o) {
+		// nothing to do here
+		// object will be garbage collected
+	}
+
 	/**
 	 * <p>Wraps around {@link VariableWrapper} and converts
 	 * {@link VariableWrapperParams} objects to JSON objects</p>

--- a/citeproc-java/src/main/java/de/undercouch/citeproc/script/ScriptRunner.java
+++ b/citeproc-java/src/main/java/de/undercouch/citeproc/script/ScriptRunner.java
@@ -14,6 +14,7 @@
 
 package de.undercouch.citeproc.script;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.Reader;
 import java.net.URL;
@@ -24,7 +25,7 @@ import de.undercouch.citeproc.helper.json.JsonBuilderFactory;
  * Executes JavaScript scripts
  * @author Michel Kraemer
  */
-public interface ScriptRunner extends JsonBuilderFactory {
+public interface ScriptRunner extends JsonBuilderFactory, Closeable {
 	/**
 	 * @return the runner's name
 	 */
@@ -103,4 +104,10 @@ public interface ScriptRunner extends JsonBuilderFactory {
 	 * @return the converted object
 	 */
 	<T> T convert(Object o, Class<T> type);
+
+	/**
+	 * Release an object and free up its resources
+	 * @param o the object to release
+	 */
+	void release(Object o);
 }

--- a/citeproc-java/src/main/java/de/undercouch/citeproc/script/V8ScriptRunner.java
+++ b/citeproc-java/src/main/java/de/undercouch/citeproc/script/V8ScriptRunner.java
@@ -57,7 +57,7 @@ public class V8ScriptRunner extends AbstractScriptRunner {
 	}
 	
 	public void release() {
-		runtime.release();
+		runtime.release(true);
 	}
 	
 	@Override
@@ -331,7 +331,7 @@ public class V8ScriptRunner extends AbstractScriptRunner {
 		/**
 		 * Retrieve an abbreviation list from the {@link AbbreviationProvider}
 		 * and convert it to a JSON object
-		 * @param id the name of the list to retrieve
+		 * @param name the name of the list to retrieve
 		 * @return the JSON object
 		 */
 		@SuppressWarnings("unused")

--- a/citeproc-java/src/main/java/de/undercouch/citeproc/script/V8ScriptRunner.java
+++ b/citeproc-java/src/main/java/de/undercouch/citeproc/script/V8ScriptRunner.java
@@ -56,10 +56,6 @@ public class V8ScriptRunner extends AbstractScriptRunner {
 		runtime = V8.createV8Runtime();
 	}
 	
-	public void release() {
-		runtime.release(true);
-	}
-	
 	@Override
 	public String getName() {
 		return "V8";
@@ -286,6 +282,20 @@ public class V8ScriptRunner extends AbstractScriptRunner {
 					m.getParameterTypes());
 		}
 		return v8o;
+	}
+
+	@Override
+	public void close() {
+		runtime.release(true);
+	}
+
+	@Override
+	public void release(Object o) {
+		if (o instanceof V8Object) {
+			((V8Object)o).release();
+		} else if (o instanceof V8Array) {
+			((V8Array)o).release();
+		}
 	}
 	
 	/**

--- a/citeproc-java/src/test/java/de/undercouch/citeproc/CSLTest.java
+++ b/citeproc-java/src/test/java/de/undercouch/citeproc/CSLTest.java
@@ -119,41 +119,42 @@ public class CSLTest {
 	 */
 	@Test
 	public void bibliography() throws Exception {
-		CSL citeproc = new CSL(new ListItemDataProvider(items), "ieee");
-		citeproc.setOutputFormat("text");
-		
-		List<Citation> a = citeproc.makeCitation(items[0].getId());
-		assertEquals(0, a.get(0).getIndex());
-		assertEquals("[1]", a.get(0).getText());
-		
-		a = citeproc.makeCitation(items[1].getId());
-		assertEquals(1, a.get(0).getIndex());
-		assertEquals("[2]", a.get(0).getText());
-		
-		a = citeproc.makeCitation(items[0].getId(), items[1].getId());
-		assertEquals(2, a.get(0).getIndex());
-		assertEquals("[1], [2]", a.get(0).getText());
-		
-		a = citeproc.makeCitation(items[2].getId(), items[0].getId());
-		assertEquals(3, a.get(0).getIndex());
-		assertEquals("[1], [3]", a.get(0).getText());
-		
-		a = citeproc.makeCitation(items[3].getId());
-		assertEquals(4, a.get(0).getIndex());
-		assertEquals("[4]", a.get(0).getText());
-		
-		Bibliography b = citeproc.makeBibliography();
-		assertEquals(4, b.getEntries().length);
-		assertEquals("[1]S. C. Johnson and B. W. Kernighan, \u201cThe Programming Language B,\u201d "
-				+ "Bell Laboratories, Murray Hill, NJ, USA, 8, 1973.\n", b.getEntries()[0]);
-		assertEquals("[2]D. M. Ritchie and K. Thompson, \u201cThe UNIX time-sharing system,\u201d "
-				+ "Operating Systems Review, vol. 7, no. 4, p. 27, Oct. 1973.\n", b.getEntries()[1]);
-		assertEquals("[3]D. M. Ritchie and K. Thompson, \u201cThe UNIX Time-Sharing System,\u201d "
-				+ "Communications of the Association for Computing Machinery, vol. 17, no. 7, pp. 365\u2013375, "
-				+ "Jul. 1974.\n", b.getEntries()[2]);
-		assertEquals("[4]H. Lycklama, \u201cUNIX Time-Sharing System: UNIX on a Microprocessor,\u201d "
-				+ "The Bell System Technical Journal, vol. 57, no. 6, pp. 2087\u20132101, "
-				+ "Jul.\u2013Aug. 1978.\n", b.getEntries()[3]);
+		try (CSL citeproc = new CSL(new ListItemDataProvider(items), "ieee")) {
+			citeproc.setOutputFormat("text");
+
+			List<Citation> a = citeproc.makeCitation(items[0].getId());
+			assertEquals(0, a.get(0).getIndex());
+			assertEquals("[1]", a.get(0).getText());
+
+			a = citeproc.makeCitation(items[1].getId());
+			assertEquals(1, a.get(0).getIndex());
+			assertEquals("[2]", a.get(0).getText());
+
+			a = citeproc.makeCitation(items[0].getId(), items[1].getId());
+			assertEquals(2, a.get(0).getIndex());
+			assertEquals("[1], [2]", a.get(0).getText());
+
+			a = citeproc.makeCitation(items[2].getId(), items[0].getId());
+			assertEquals(3, a.get(0).getIndex());
+			assertEquals("[1], [3]", a.get(0).getText());
+
+			a = citeproc.makeCitation(items[3].getId());
+			assertEquals(4, a.get(0).getIndex());
+			assertEquals("[4]", a.get(0).getText());
+
+			Bibliography b = citeproc.makeBibliography();
+			assertEquals(4, b.getEntries().length);
+			assertEquals("[1]S. C. Johnson and B. W. Kernighan, \u201cThe Programming Language B,\u201d "
+					+ "Bell Laboratories, Murray Hill, NJ, USA, 8, 1973.\n", b.getEntries()[0]);
+			assertEquals("[2]D. M. Ritchie and K. Thompson, \u201cThe UNIX time-sharing system,\u201d "
+					+ "Operating Systems Review, vol. 7, no. 4, p. 27, Oct. 1973.\n", b.getEntries()[1]);
+			assertEquals("[3]D. M. Ritchie and K. Thompson, \u201cThe UNIX Time-Sharing System,\u201d "
+					+ "Communications of the Association for Computing Machinery, vol. 17, no. 7, pp. 365\u2013375, "
+					+ "Jul. 1974.\n", b.getEntries()[2]);
+			assertEquals("[4]H. Lycklama, \u201cUNIX Time-Sharing System: UNIX on a Microprocessor,\u201d "
+					+ "The Bell System Technical Journal, vol. 57, no. 6, pp. 2087\u20132101, "
+					+ "Jul.\u2013Aug. 1978.\n", b.getEntries()[3]);
+		}
 	}
 	
 	/**
@@ -162,21 +163,22 @@ public class CSLTest {
 	 */
 	@Test
 	public void bibliographySelection() throws Exception {
-		CSL citeproc = new CSL(new ListItemDataProvider(items), "ieee");
-		citeproc.setOutputFormat("text");
-		
-		List<Citation> a = citeproc.makeCitation(items[0].getId());
-		assertEquals(0, a.get(0).getIndex());
-		assertEquals("[1]", a.get(0).getText());
-		
-		a = citeproc.makeCitation(items[1].getId());
-		assertEquals(1, a.get(0).getIndex());
-		assertEquals("[2]", a.get(0).getText());
-		
-		Bibliography b = citeproc.makeBibliography(SelectionMode.SELECT,
-				new CSLItemDataBuilder().title("The Programming Language B").build());
-		assertEquals(1, b.getEntries().length);
-		assertTrue(b.getEntries()[0].startsWith("[1]S. C. Johnson"));
+		try (CSL citeproc = new CSL(new ListItemDataProvider(items), "ieee")) {
+			citeproc.setOutputFormat("text");
+
+			List<Citation> a = citeproc.makeCitation(items[0].getId());
+			assertEquals(0, a.get(0).getIndex());
+			assertEquals("[1]", a.get(0).getText());
+
+			a = citeproc.makeCitation(items[1].getId());
+			assertEquals(1, a.get(0).getIndex());
+			assertEquals("[2]", a.get(0).getText());
+
+			Bibliography b = citeproc.makeBibliography(SelectionMode.SELECT,
+					new CSLItemDataBuilder().title("The Programming Language B").build());
+			assertEquals(1, b.getEntries().length);
+			assertTrue(b.getEntries()[0].startsWith("[1]S. C. Johnson"));
+		}
 	}
 	
 	/**
@@ -208,8 +210,9 @@ public class CSLTest {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void missingItem() throws Exception {
-		CSL citeproc = new CSL(new ListItemDataProvider(items), "ieee");
-		citeproc.makeCitation("foobar");
+		try (CSL citeproc = new CSL(new ListItemDataProvider(items), "ieee")) {
+			citeproc.makeCitation("foobar");
+		}
 	}
 	
 	/**
@@ -228,23 +231,24 @@ public class CSLTest {
 			.accessed(2013, 9, 11)
 			.build();
 		
-		CSL citeproc = new CSL(new ListItemDataProvider(item), "ieee");
-		citeproc.setOutputFormat("html");
-		citeproc.setConvertLinks(true);
-		
-		List<Citation> a = citeproc.makeCitation("citeproc-java");
-		assertEquals(0, a.get(0).getIndex());
-		assertEquals("[1]", a.get(0).getText());
-		
-		Bibliography b = citeproc.makeBibliography();
-		assertEquals(1, b.getEntries().length);
-		assertEquals("  <div class=\"csl-entry\">\n"
-				+ "    <div class=\"csl-left-margin\">[1]</div><div class=\"csl-right-inline\">"
-				+ "M. Kr\u00E4mer, \u201cciteproc-java: A Citation Style Language (CSL) processor for Java,\u201d"
-				+ " 09-Sep-2013. [Online]. Available: "
-				+ "<a href=\"http://michel-kraemer.github.io/citeproc-java/\">http://michel-kraemer.github.io/citeproc-java/</a>. "
-				+ "[Accessed: 11-Sep-2013].</div>\n"
-				+ "  </div>\n", b.getEntries()[0]);
+		try (CSL citeproc = new CSL(new ListItemDataProvider(item), "ieee")) {
+			citeproc.setOutputFormat("html");
+			citeproc.setConvertLinks(true);
+
+			List<Citation> a = citeproc.makeCitation("citeproc-java");
+			assertEquals(0, a.get(0).getIndex());
+			assertEquals("[1]", a.get(0).getText());
+
+			Bibliography b = citeproc.makeBibliography();
+			assertEquals(1, b.getEntries().length);
+			assertEquals("  <div class=\"csl-entry\">\n"
+					+ "    <div class=\"csl-left-margin\">[1]</div><div class=\"csl-right-inline\">"
+					+ "M. Kr\u00E4mer, \u201cciteproc-java: A Citation Style Language (CSL) processor for Java,\u201d"
+					+ " 09-Sep-2013. [Online]. Available: "
+					+ "<a href=\"http://michel-kraemer.github.io/citeproc-java/\">http://michel-kraemer.github.io/citeproc-java/</a>. "
+					+ "[Accessed: 11-Sep-2013].</div>\n"
+					+ "  </div>\n", b.getEntries()[0]);
+		}
 	}
 	
 	/**
@@ -263,17 +267,18 @@ public class CSLTest {
 			.accessed(2013, 9, 11)
 			.build();
 		
-		CSL citeproc = new CSL(new ListItemDataProvider(item), "ieee");
-		citeproc.setOutputFormat("asciidoc");
-		citeproc.makeCitation("citeproc-java");
-		
-		Bibliography b = citeproc.makeBibliography();
-		
-		assertEquals(1, b.getEntries().length);
-		assertEquals("[1] M. Kr\u00E4mer, ``citeproc-java: A Citation Style "
-				+ "Language (CSL) processor for Java,'' 09-Sep-2013. [Online]. "
-				+ "Available: http://michel-kraemer.github.io/citeproc-java/. "
-				+ "[Accessed: 11-Sep-2013].\n", b.getEntries()[0]);
+		try (CSL citeproc = new CSL(new ListItemDataProvider(item), "ieee")) {
+			citeproc.setOutputFormat("asciidoc");
+			citeproc.makeCitation("citeproc-java");
+
+			Bibliography b = citeproc.makeBibliography();
+
+			assertEquals(1, b.getEntries().length);
+			assertEquals("[1] M. Kr\u00E4mer, ``citeproc-java: A Citation Style "
+					+ "Language (CSL) processor for Java,'' 09-Sep-2013. [Online]. "
+					+ "Available: http://michel-kraemer.github.io/citeproc-java/. "
+					+ "[Accessed: 11-Sep-2013].\n", b.getEntries()[0]);
+		}
 	}
 	
 	/**
@@ -282,31 +287,32 @@ public class CSLTest {
 	 */
 	@Test
 	public void asciiFOFormat() throws Exception {
-		CSL citeproc = new CSL(new ListItemDataProvider(items), "ieee");
-		citeproc.setOutputFormat("fo");
-		citeproc.makeCitation(items[0].getId());
-		
-		Bibliography b = citeproc.makeBibliography();
-		
-		assertEquals(1, b.getEntries().length);
-		assertEquals("<fo:block id=\"Johnson:1973:PLB\">\n"
-				+ "  <fo:table table-layout=\"fixed\" width=\"100%\">\n"
-				+ "    <fo:table-column column-number=\"1\" column-width=\"2.5em\"/>\n"
-				+ "    <fo:table-column column-number=\"2\" column-width=\"proportional-column-width(1)\"/>\n"
-				+ "    <fo:table-body>\n"
-				+ "      <fo:table-row>\n"
-				+ "        <fo:table-cell>\n"
-				+ "          <fo:block>[1]</fo:block>\n"
-				+ "        </fo:table-cell>\n"
-				+ "        <fo:table-cell>\n"
-				+ "          <fo:block>S. C. Johnson and B. W. Kernighan, "
-				+ "\u201cThe Programming Language B,\u201d Bell Laboratories, "
-				+ "Murray Hill, NJ, USA, 8, 1973.</fo:block>\n"
-				+ "        </fo:table-cell>\n"
-				+ "      </fo:table-row>\n"
-				+ "    </fo:table-body>\n"
-				+ "  </fo:table>\n"
-				+ "</fo:block>\n", b.getEntries()[0]);
+		try (CSL citeproc = new CSL(new ListItemDataProvider(items), "ieee")) {
+			citeproc.setOutputFormat("fo");
+			citeproc.makeCitation(items[0].getId());
+
+			Bibliography b = citeproc.makeBibliography();
+
+			assertEquals(1, b.getEntries().length);
+			assertEquals("<fo:block id=\"Johnson:1973:PLB\">\n"
+					+ "  <fo:table table-layout=\"fixed\" width=\"100%\">\n"
+					+ "    <fo:table-column column-number=\"1\" column-width=\"2.5em\"/>\n"
+					+ "    <fo:table-column column-number=\"2\" column-width=\"proportional-column-width(1)\"/>\n"
+					+ "    <fo:table-body>\n"
+					+ "      <fo:table-row>\n"
+					+ "        <fo:table-cell>\n"
+					+ "          <fo:block>[1]</fo:block>\n"
+					+ "        </fo:table-cell>\n"
+					+ "        <fo:table-cell>\n"
+					+ "          <fo:block>S. C. Johnson and B. W. Kernighan, "
+					+ "\u201cThe Programming Language B,\u201d Bell Laboratories, "
+					+ "Murray Hill, NJ, USA, 8, 1973.</fo:block>\n"
+					+ "        </fo:table-cell>\n"
+					+ "      </fo:table-row>\n"
+					+ "    </fo:table-body>\n"
+					+ "  </fo:table>\n"
+					+ "</fo:block>\n", b.getEntries()[0]);
+		}
 	}
 	
 	/**
@@ -315,20 +321,21 @@ public class CSLTest {
 	 */
 	@Test
 	public void reset() throws Exception {
-		CSL citeproc = new CSL(new ListItemDataProvider(items), "ieee");
-		citeproc.setOutputFormat("text");
-		
-		List<Citation> a = citeproc.makeCitation(items[0].getId());
-		assertEquals(0, a.get(0).getIndex());
-		assertEquals("[1]", a.get(0).getText());
-		
-		Bibliography b = citeproc.makeBibliography();
-		assertEquals(1, b.getEntries().length);
-		
-		citeproc.reset();
-		
-		b = citeproc.makeBibliography();
-		assertEquals(0, b.getEntries().length);
+		try (CSL citeproc = new CSL(new ListItemDataProvider(items), "ieee")) {
+			citeproc.setOutputFormat("text");
+
+			List<Citation> a = citeproc.makeCitation(items[0].getId());
+			assertEquals(0, a.get(0).getIndex());
+			assertEquals("[1]", a.get(0).getText());
+
+			Bibliography b = citeproc.makeBibliography();
+			assertEquals(1, b.getEntries().length);
+
+			citeproc.reset();
+
+			b = citeproc.makeBibliography();
+			assertEquals(0, b.getEntries().length);
+		}
 	}
 	
 	/**
@@ -354,57 +361,58 @@ public class CSLTest {
 	 */
 	@Test
 	public void makeCitationPrePost() throws Exception {
-		CSL citeproc = new CSL(new ListItemDataProvider(items), "ieee");
-		citeproc.setOutputFormat("text");
-		
-		CSLCitation cit1 = new CSLCitation(new CSLCitationItem[] {
-				new CSLCitationItem(items[0].getId()) }, "CITATION-1",
-				new CSLPropertiesBuilder().noteIndex(1).build());
-		CSLCitation cit2 = new CSLCitation(new CSLCitationItem[] {
-				new CSLCitationItem(items[2].getId()) }, "CITATION-2",
-				new CSLPropertiesBuilder().noteIndex(2).build());
-		CSLCitation cit3 = new CSLCitation(new CSLCitationItem[] {
-				new CSLCitationItem(items[3].getId()) }, "CITATION-3",
-				new CSLPropertiesBuilder().noteIndex(3).build());
-		CSLCitation cit4 = new CSLCitation(new CSLCitationItem[] {
-				new CSLCitationItem(items[2].getId()) }, "CITATION-4",
-				new CSLPropertiesBuilder().noteIndex(2).build());
-		
-		List<Citation> a1 = citeproc.makeCitation(cit1,
-				Collections.<CitationIDIndexPair>emptyList(),
-				Collections.<CitationIDIndexPair>emptyList());
-		List<Citation> a2 = citeproc.makeCitation(cit2,
-				Arrays.asList(new CitationIDIndexPair(cit1)),
-				Collections.<CitationIDIndexPair>emptyList());
-		List<Citation> a3 = citeproc.makeCitation(cit3,
-				Arrays.asList(new CitationIDIndexPair(cit1)),
-				Arrays.asList(new CitationIDIndexPair(cit2)));
-		List<Citation> a4 = citeproc.makeCitation(cit4,
-				Arrays.asList(new CitationIDIndexPair(cit1)),
-				Arrays.asList(new CitationIDIndexPair(cit2), new CitationIDIndexPair(cit3)));
-		
-		assertEquals(1, a1.size());
-		assertEquals("[1]", a1.get(0).getText());
-		assertEquals(0, a1.get(0).getIndex());
-		
-		assertEquals(1, a2.size());
-		assertEquals("[2]", a2.get(0).getText());
-		assertEquals(1, a2.get(0).getIndex());
-		
-		assertEquals(2, a3.size());
-		assertEquals("[2]", a3.get(0).getText());
-		assertEquals(1, a3.get(0).getIndex());
-		assertEquals("[3]", a3.get(1).getText());
-		assertEquals(2, a3.get(1).getIndex());
-		
-		//we should now have two items with ID [2], but different indexes
-		assertEquals(3, a4.size());
-		assertEquals("[2]", a4.get(0).getText());
-		assertEquals(1, a4.get(0).getIndex());
-		assertEquals("[2]", a4.get(1).getText());
-		assertEquals(2, a4.get(1).getIndex());
-		assertEquals("[3]", a4.get(2).getText());
-		assertEquals(3, a4.get(2).getIndex());
+		try (CSL citeproc = new CSL(new ListItemDataProvider(items), "ieee")) {
+			citeproc.setOutputFormat("text");
+
+			CSLCitation cit1 = new CSLCitation(new CSLCitationItem[] {
+					new CSLCitationItem(items[0].getId()) }, "CITATION-1",
+					new CSLPropertiesBuilder().noteIndex(1).build());
+			CSLCitation cit2 = new CSLCitation(new CSLCitationItem[] {
+					new CSLCitationItem(items[2].getId()) }, "CITATION-2",
+					new CSLPropertiesBuilder().noteIndex(2).build());
+			CSLCitation cit3 = new CSLCitation(new CSLCitationItem[] {
+					new CSLCitationItem(items[3].getId()) }, "CITATION-3",
+					new CSLPropertiesBuilder().noteIndex(3).build());
+			CSLCitation cit4 = new CSLCitation(new CSLCitationItem[] {
+					new CSLCitationItem(items[2].getId()) }, "CITATION-4",
+					new CSLPropertiesBuilder().noteIndex(2).build());
+
+			List<Citation> a1 = citeproc.makeCitation(cit1,
+					Collections.<CitationIDIndexPair>emptyList(),
+					Collections.<CitationIDIndexPair>emptyList());
+			List<Citation> a2 = citeproc.makeCitation(cit2,
+					Arrays.asList(new CitationIDIndexPair(cit1)),
+					Collections.<CitationIDIndexPair>emptyList());
+			List<Citation> a3 = citeproc.makeCitation(cit3,
+					Arrays.asList(new CitationIDIndexPair(cit1)),
+					Arrays.asList(new CitationIDIndexPair(cit2)));
+			List<Citation> a4 = citeproc.makeCitation(cit4,
+					Arrays.asList(new CitationIDIndexPair(cit1)),
+					Arrays.asList(new CitationIDIndexPair(cit2), new CitationIDIndexPair(cit3)));
+
+			assertEquals(1, a1.size());
+			assertEquals("[1]", a1.get(0).getText());
+			assertEquals(0, a1.get(0).getIndex());
+
+			assertEquals(1, a2.size());
+			assertEquals("[2]", a2.get(0).getText());
+			assertEquals(1, a2.get(0).getIndex());
+
+			assertEquals(2, a3.size());
+			assertEquals("[2]", a3.get(0).getText());
+			assertEquals(1, a3.get(0).getIndex());
+			assertEquals("[3]", a3.get(1).getText());
+			assertEquals(2, a3.get(1).getIndex());
+
+			//we should now have two items with ID [2], but different indexes
+			assertEquals(3, a4.size());
+			assertEquals("[2]", a4.get(0).getText());
+			assertEquals(1, a4.get(0).getIndex());
+			assertEquals("[2]", a4.get(1).getText());
+			assertEquals(2, a4.get(1).getIndex());
+			assertEquals("[3]", a4.get(2).getText());
+			assertEquals(3, a4.get(2).getIndex());
+		}
 	}
 	
 	/**
@@ -423,13 +431,14 @@ public class CSLTest {
 		DefaultAbbreviationProvider prov = new DefaultAbbreviationProvider();
 		prov.add(AbbreviationProvider.DEFAULT_LIST_NAME, abbrevs);
 		
-		CSL citeproc = new CSL(new ListItemDataProvider(items), prov, "chicago-note-bibliography");
-		citeproc.setOutputFormat("text");
-		citeproc.setAbbreviations(AbbreviationProvider.DEFAULT_LIST_NAME);
-		
-		List<Citation> a = citeproc.makeCitation(items[0].getId());
-		assertEquals(0, a.get(0).getIndex());
-		assertEquals("Johnson and Kernighan, \u201cB.\u201d", a.get(0).getText());
+		try (CSL citeproc = new CSL(new ListItemDataProvider(items), prov, "chicago-note-bibliography")) {
+			citeproc.setOutputFormat("text");
+			citeproc.setAbbreviations(AbbreviationProvider.DEFAULT_LIST_NAME);
+
+			List<Citation> a = citeproc.makeCitation(items[0].getId());
+			assertEquals(0, a.get(0).getIndex());
+			assertEquals("Johnson and Kernighan, \u201cB.\u201d", a.get(0).getText());
+		}
 	}
 	
 	/**
@@ -450,15 +459,15 @@ public class CSLTest {
 			}
 		};
 		
-		CSL citeproc = new CSL(new ListItemDataProvider(items),
+		try (CSL citeproc = new CSL(new ListItemDataProvider(items),
 				new DefaultLocaleProvider(), new DefaultAbbreviationProvider(),
-				wrapper, "chicago-note-bibliography", "en-US", false);
-		
-		List<Citation> a = citeproc.makeCitation(items[0].getId());
-		assertEquals(0, a.get(0).getIndex());
-		assertEquals("<strong>Johnson and Kernighan</strong>, "
-				+ "\u201cThe Programming Language B.\u201d",
-				a.get(0).getText());
+				wrapper, "chicago-note-bibliography", "en-US", false)) {
+			List<Citation> a = citeproc.makeCitation(items[0].getId());
+			assertEquals(0, a.get(0).getIndex());
+			assertEquals("<strong>Johnson and Kernighan</strong>, "
+					+ "\u201cThe Programming Language B.\u201d",
+					a.get(0).getText());
+		}
 	}
 	
 	/**
@@ -467,24 +476,25 @@ public class CSLTest {
 	 */
 	@Test
 	public void registerUnsorted() throws Exception {
-		CSL citeproc = new CSL(new ListItemDataProvider(items), "chicago-note-bibliography");
-		citeproc.setOutputFormat("text");
-		
-		String[] ids = new String[] { items[0].getId(), items[1].getId(), items[3].getId() };
-		citeproc.registerCitationItems(ids);
-		
-		Bibliography b = citeproc.makeBibliography();
-		assertEquals(3, b.getEntries().length);
-		assertTrue(b.getEntries()[0].startsWith("Johnson"));
-		assertTrue(b.getEntries()[1].startsWith("Lycklama"));
-		assertTrue(b.getEntries()[2].startsWith("Ritchie"));
-		
-		citeproc.registerCitationItems(ids, true);
-		b = citeproc.makeBibliography();
-		assertEquals(3, b.getEntries().length);
-		assertTrue(b.getEntries()[0].startsWith("Johnson"));
-		assertTrue(b.getEntries()[1].startsWith("Ritchie"));
-		assertTrue(b.getEntries()[2].startsWith("Lycklama"));
+		try (CSL citeproc = new CSL(new ListItemDataProvider(items), "chicago-note-bibliography")) {
+			citeproc.setOutputFormat("text");
+
+			String[] ids = new String[] { items[0].getId(), items[1].getId(), items[3].getId() };
+			citeproc.registerCitationItems(ids);
+
+			Bibliography b = citeproc.makeBibliography();
+			assertEquals(3, b.getEntries().length);
+			assertTrue(b.getEntries()[0].startsWith("Johnson"));
+			assertTrue(b.getEntries()[1].startsWith("Lycklama"));
+			assertTrue(b.getEntries()[2].startsWith("Ritchie"));
+
+			citeproc.registerCitationItems(ids, true);
+			b = citeproc.makeBibliography();
+			assertEquals(3, b.getEntries().length);
+			assertTrue(b.getEntries()[0].startsWith("Johnson"));
+			assertTrue(b.getEntries()[1].startsWith("Ritchie"));
+			assertTrue(b.getEntries()[2].startsWith("Lycklama"));
+		}
 	}
 	
 	/**

--- a/citeproc-java/src/test/java/de/undercouch/citeproc/bibtex/BibTeXItemDataProviderTest.java
+++ b/citeproc-java/src/test/java/de/undercouch/citeproc/bibtex/BibTeXItemDataProviderTest.java
@@ -54,45 +54,46 @@ public class BibTeXItemDataProviderTest extends AbstractBibTeXTest {
 	 */
 	@Test
 	public void bibliography() throws Exception {
-		CSL citeproc = new CSL(sys, "ieee");
-		citeproc.setOutputFormat("text");
-		
-		String id0 = "Johnson:1973:PLB";
-		String id1 = "Ritchie:1973:UTS";
-		String id2 = "Ritchie:1974:UTS";
-		String id3 = "Lycklama:1978:UTSb";
-		List<Citation> a = citeproc.makeCitation(id0);
-		assertEquals(0, a.get(0).getIndex());
-		assertEquals("[1]", a.get(0).getText());
-		
-		a = citeproc.makeCitation(id1);
-		assertEquals(1, a.get(0).getIndex());
-		assertEquals("[2]", a.get(0).getText());
-		
-		a = citeproc.makeCitation(id0, id1);
-		assertEquals(2, a.get(0).getIndex());
-		assertEquals("[1], [2]", a.get(0).getText());
-		
-		a = citeproc.makeCitation(id2, id0);
-		assertEquals(3, a.get(0).getIndex());
-		assertEquals("[1], [3]", a.get(0).getText());
-		
-		a = citeproc.makeCitation(id3);
-		assertEquals(4, a.get(0).getIndex());
-		assertEquals("[4]", a.get(0).getText());
-		
-		Bibliography b = citeproc.makeBibliography();
-		assertEquals(4, b.getEntries().length);
-		assertEquals("[1]S. C. Johnson and B. W. Kernighan, \u201cThe Programming Language B,\u201d "
-				+ "Bell Laboratories, Murray Hill, NJ, USA, 8, 1973.\n", b.getEntries()[0]);
-		assertEquals("[2]D. M. Ritchie and K. Thompson, \u201cThe UNIX time-sharing system,\u201d "
-				+ "Operating Systems Review, vol. 7, no. 4, p. 27, Oct. 1973.\n", b.getEntries()[1]);
-		assertEquals("[3]D. W. Ritchie and K. Thompson, \u201cThe UNIX Time-Sharing System,\u201d "
-				+ "Communications of the Association for Computing Machinery, vol. 17, no. 7, pp. 365\u2013375, "
-				+ "Jul. 1974.\n", b.getEntries()[2]);
-		assertEquals("[4]H. Lycklama, \u201cUNIX Time-Sharing System: UNIX on a Microprocessor,\u201d "
-				+ "The Bell System Technical Journal, vol. 57, no. 6, pp. 2087\u20132101, "
-				+ "Jul.\u2013Aug. 1978.\n", b.getEntries()[3]);
+		try (CSL citeproc = new CSL(sys, "ieee")) {
+			citeproc.setOutputFormat("text");
+
+			String id0 = "Johnson:1973:PLB";
+			String id1 = "Ritchie:1973:UTS";
+			String id2 = "Ritchie:1974:UTS";
+			String id3 = "Lycklama:1978:UTSb";
+			List<Citation> a = citeproc.makeCitation(id0);
+			assertEquals(0, a.get(0).getIndex());
+			assertEquals("[1]", a.get(0).getText());
+
+			a = citeproc.makeCitation(id1);
+			assertEquals(1, a.get(0).getIndex());
+			assertEquals("[2]", a.get(0).getText());
+
+			a = citeproc.makeCitation(id0, id1);
+			assertEquals(2, a.get(0).getIndex());
+			assertEquals("[1], [2]", a.get(0).getText());
+
+			a = citeproc.makeCitation(id2, id0);
+			assertEquals(3, a.get(0).getIndex());
+			assertEquals("[1], [3]", a.get(0).getText());
+
+			a = citeproc.makeCitation(id3);
+			assertEquals(4, a.get(0).getIndex());
+			assertEquals("[4]", a.get(0).getText());
+
+			Bibliography b = citeproc.makeBibliography();
+			assertEquals(4, b.getEntries().length);
+			assertEquals("[1]S. C. Johnson and B. W. Kernighan, \u201cThe Programming Language B,\u201d "
+					+ "Bell Laboratories, Murray Hill, NJ, USA, 8, 1973.\n", b.getEntries()[0]);
+			assertEquals("[2]D. M. Ritchie and K. Thompson, \u201cThe UNIX time-sharing system,\u201d "
+					+ "Operating Systems Review, vol. 7, no. 4, p. 27, Oct. 1973.\n", b.getEntries()[1]);
+			assertEquals("[3]D. W. Ritchie and K. Thompson, \u201cThe UNIX Time-Sharing System,\u201d "
+					+ "Communications of the Association for Computing Machinery, vol. 17, no. 7, pp. 365\u2013375, "
+					+ "Jul. 1974.\n", b.getEntries()[2]);
+			assertEquals("[4]H. Lycklama, \u201cUNIX Time-Sharing System: UNIX on a Microprocessor,\u201d "
+					+ "The Bell System Technical Journal, vol. 57, no. 6, pp. 2087\u20132101, "
+					+ "Jul.\u2013Aug. 1978.\n", b.getEntries()[3]);
+		}
 	}
 	
 	/**
@@ -101,34 +102,35 @@ public class BibTeXItemDataProviderTest extends AbstractBibTeXTest {
 	 */
 	@Test
 	public void numericAlphabetical() throws Exception {
-		CSL citeproc = new CSL(sys, "din-1505-2-numeric-alphabetical");
-		citeproc.setOutputFormat("text");
-		
-		List<Key> keys = new ArrayList<>(db.getEntries().keySet());
-		List<String> result = new ArrayList<>();
-		List<Integer> rnds = new ArrayList<>();
-		for (int i = 0; i < 10; ++i) {
-			int j = (int)(Math.random() * keys.size());
-			rnds.add(j);
-			Key k = keys.get(j);
-			List<Citation> cs = citeproc.makeCitation(k.getValue());
-			for (Citation c : cs) {
-				while (result.size() <= c.getIndex()) {
-					result.add("");
+		try (CSL citeproc = new CSL(sys, "din-1505-2-numeric-alphabetical")) {
+			citeproc.setOutputFormat("text");
+
+			List<Key> keys = new ArrayList<>(db.getEntries().keySet());
+			List<String> result = new ArrayList<>();
+			List<Integer> rnds = new ArrayList<>();
+			for (int i = 0; i < 10; ++i) {
+				int j = (int)(Math.random() * keys.size());
+				rnds.add(j);
+				Key k = keys.get(j);
+				List<Citation> cs = citeproc.makeCitation(k.getValue());
+				for (Citation c : cs) {
+					while (result.size() <= c.getIndex()) {
+						result.add("");
+					}
+					result.set(c.getIndex(), c.getText());
 				}
-				result.set(c.getIndex(), c.getText());
 			}
-		}
-		
-		int c = 0;
-		for (Integer r : rnds) {
-			Key k = keys.get(r);
-			List<Citation> cs = citeproc.makeCitation(k.getValue());
-			assertEquals(1, cs.size());
-			String nc = cs.get(0).getText();
-			String pc = result.get(c);
-			assertEquals(nc, pc);
-			++c;
+
+			int c = 0;
+			for (Integer r : rnds) {
+				Key k = keys.get(r);
+				List<Citation> cs = citeproc.makeCitation(k.getValue());
+				assertEquals(1, cs.size());
+				String nc = cs.get(0).getText();
+				String pc = result.get(c);
+				assertEquals(nc, pc);
+				++c;
+			}
 		}
 	}
 	
@@ -155,16 +157,17 @@ public class BibTeXItemDataProviderTest extends AbstractBibTeXTest {
 		BibTeXItemDataProvider sys = new BibTeXItemDataProvider();
 		sys.addDatabase(db);
 		
-		CSL citeproc = new CSL(sys, "ieee");
-		citeproc.setOutputFormat("text");
-		sys.registerCitationItems(citeproc);
-		
-		Bibliography bibl = citeproc.makeBibliography();
-		for (String e : bibl.getEntries()) {
-			assertEquals("[1]M. G. Strintzis and I. Kompatsiaris, "
-					+ "\u201c3D Model-Based Segmentation of Videoconference "
-					+ "Image Sequences,\u201d in IEEE International Conference "
-					+ "on Image Processing (ICIP), Kobe, Japan, 1999.", e.trim());
+		try (CSL citeproc = new CSL(sys, "ieee")) {
+			citeproc.setOutputFormat("text");
+			sys.registerCitationItems(citeproc);
+
+			Bibliography bibl = citeproc.makeBibliography();
+			for (String e : bibl.getEntries()) {
+				assertEquals("[1]M. G. Strintzis and I. Kompatsiaris, "
+						+ "\u201c3D Model-Based Segmentation of Videoconference "
+						+ "Image Sequences,\u201d in IEEE International Conference "
+						+ "on Image Processing (ICIP), Kobe, Japan, 1999.", e.trim());
+			}
 		}
 	}
 	
@@ -175,41 +178,43 @@ public class BibTeXItemDataProviderTest extends AbstractBibTeXTest {
 	@Test
 	public void noCollectionAuthor() throws Exception {
 		// compare with an item from the unix database
-		CSL citeproc = new CSL(sys, "apa");
-		citeproc.setOutputFormat("text");
-		
-		List<Citation> a = citeproc.makeCitation("Sterling:2001:BCCa");
-		assertEquals("(Sterling, 2001)", a.get(0).getText());
-		
-		Bibliography b = citeproc.makeBibliography();
-		assertEquals(1, b.getEntries().length);
-		assertEquals("Sterling, T. L. (Ed.). (2001). Beowulf Cluster Computing with Linux "
-				+ "(p. xxxiii,496). Cambridge, MA, USA: MIT Press.\n", b.getEntries()[0]);
-		
+		try (CSL citeproc = new CSL(sys, "apa")) {
+			citeproc.setOutputFormat("text");
+
+			List<Citation> a = citeproc.makeCitation("Sterling:2001:BCCa");
+			assertEquals("(Sterling, 2001)", a.get(0).getText());
+
+			Bibliography b = citeproc.makeBibliography();
+			assertEquals(1, b.getEntries().length);
+			assertEquals("Sterling, T. L. (Ed.). (2001). Beowulf Cluster Computing with Linux "
+					+ "(p. xxxiii,496). Cambridge, MA, USA: MIT Press.\n", b.getEntries()[0]);
+		}
+
 		// compare with the item from issue #38
 		String entry = "@book{EconBiz-10009450595," +
-			"title = {{Essays on the Role of Specific Human Capital}}," +
-			"author = {Hu, Xiaohan}," +
-			"editor = {Hellerstein, Judith}," +
-			"year = {2007-06-04}," +
-			"type= {Thesis}," +
-			"language= {eng}," +
-		"}";
+				"title = {{Essays on the Role of Specific Human Capital}}," +
+				"author = {Hu, Xiaohan}," +
+				"editor = {Hellerstein, Judith}," +
+				"year = {2007-06-04}," +
+				"type= {Thesis}," +
+				"language= {eng}," +
+				"}";
 
 		ByteArrayInputStream bais = new ByteArrayInputStream(
 				entry.getBytes(StandardCharsets.UTF_8));
-		
+
 		BibTeXDatabase db = new BibTeXConverter().loadDatabase(bais);
 		BibTeXItemDataProvider sys = new BibTeXItemDataProvider();
 		sys.addDatabase(db);
-		
-		citeproc = new CSL(sys, "apa");
-		citeproc.setOutputFormat("text");
-		sys.registerCitationItems(citeproc);
-		
-		b = citeproc.makeBibliography();
-		assertEquals(1, b.getEntries().length);
-		assertEquals("Hu, X. (2007). Essays on the Role of Specific Human Capital. "
-				+ "(J. Hellerstein, Ed.).\n", b.getEntries()[0]);
+
+		try (CSL citeproc = new CSL(sys, "apa")) {
+			citeproc.setOutputFormat("text");
+			sys.registerCitationItems(citeproc);
+
+			Bibliography b = citeproc.makeBibliography();
+			assertEquals(1, b.getEntries().length);
+			assertEquals("Hu, X. (2007). Essays on the Role of Specific Human "
+					+ "Capital. (J. Hellerstein, Ed.).\n", b.getEntries()[0]);
+		}
 	}
 }

--- a/citeproc-java/src/test/java/de/undercouch/citeproc/script/ScriptRunnerBenchmark.java
+++ b/citeproc-java/src/test/java/de/undercouch/citeproc/script/ScriptRunnerBenchmark.java
@@ -66,32 +66,33 @@ public class ScriptRunnerBenchmark extends AbstractBibTeXTest {
 	}
 	
 	private void runTest() throws Exception {
-		CSL citeproc = new CSL(sys, "ieee");
-		citeproc.setOutputFormat("text");
-		
-		List<Key> keys = new ArrayList<>(db.getEntries().keySet());
-		List<String> result = new ArrayList<>();
-		
-		for (Integer r : rnds) {
-			Key k = keys.get(r);
-			List<Citation> cs = citeproc.makeCitation(k.getValue());
-			for (Citation c : cs) {
-				while (result.size() <= c.getIndex()) {
-					result.add("");
+		try (CSL citeproc = new CSL(sys, "ieee")) {
+			citeproc.setOutputFormat("text");
+
+			List<Key> keys = new ArrayList<>(db.getEntries().keySet());
+			List<String> result = new ArrayList<>();
+
+			for (Integer r : rnds) {
+				Key k = keys.get(r);
+				List<Citation> cs = citeproc.makeCitation(k.getValue());
+				for (Citation c : cs) {
+					while (result.size() <= c.getIndex()) {
+						result.add("");
+					}
+					result.set(c.getIndex(), c.getText());
 				}
-				result.set(c.getIndex(), c.getText());
 			}
-		}
-		
-		int c = 0;
-		for (Integer r : rnds) {
-			Key k = keys.get(r);
-			List<Citation> cs = citeproc.makeCitation(k.getValue());
-			assertEquals(1, cs.size());
-			String nc = cs.get(0).getText();
-			String pc = result.get(c);
-			assertEquals(nc, pc);
-			++c;
+
+			int c = 0;
+			for (Integer r : rnds) {
+				Key k = keys.get(r);
+				List<Citation> cs = citeproc.makeCitation(k.getValue());
+				assertEquals(1, cs.size());
+				String nc = cs.get(0).getText();
+				String pc = result.get(c);
+				assertEquals(nc, pc);
+				++c;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #45

When using `V8ScriptRunner`, the engine is a `V8Object` returned by an `executeObjectFunction`. This object is now explicitly released in `makeAdhocBibliography`.

Additionally, releasing the `V8ScriptRunner` reports mem leaks.