### PR TITLE
build: Allow versioning from the command line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ build/
 target/
 reports/
 src-gen/
-gradle.properties
 
 bin/
 out/

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'eclipse'
     
-    version = '2.0.0-SNAPSHOT'
     group = 'de.undercouch'
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+version = '2.0.0-SNAPSHOT'


### PR DESCRIPTION
Use `gradle (-Pversion=...)` to explicitly set the target version.

(See https://stackoverflow.com/a/40239092/413020.)