### PR TITLE
runTestSuite: switch to processor.py (#60)

### DIFF
--- a/buildSrc/src/main/groovy/CSLTestSuite.groovy
+++ b/buildSrc/src/main/groovy/CSLTestSuite.groovy
@@ -1,6 +1,3 @@
-import java.lang.reflect.Array
-import org.fusesource.jansi.Ansi
-import org.fusesource.jansi.AnsiConsole
 import org.python.core.PyString
 import org.python.core.PySystemState
 import org.python.util.PythonInterpreter
@@ -13,7 +10,7 @@ class CSLTestSuite {
     CSLTestSuite(project, path) {
         this.project = project
         
-        testPyFile = new File(path, 'test.py')
+        testPyFile = new File(path, 'fixtures/std/processor.py')
         
         def cp = project.test.classpath
         def urls = cp.files.collect { it.toURI().toURL() }
@@ -41,7 +38,7 @@ class CSLTestSuite {
     }
     
     private def fixInFile(name, s, d) {
-        def dir = new File(testPyFile.getParentFile(), 'tests/fixtures/run/machines')
+        def dir = new File(testPyFile.getParentFile(), 'processor-tests/machines')
         def f = new File(dir, name)
         def found = false
         def tempFile = File.createTempFile('citeproc', 'json')
@@ -63,7 +60,7 @@ class CSLTestSuite {
     }
     
     def run() {
-        def dir = new File(testPyFile.getParentFile(), 'tests/fixtures/run/machines')
+        def dir = new File(testPyFile.getParentFile(), 'processor-tests/machines')
         
         def runnerTypeClass = cl.loadClass('de.undercouch.citeproc.script.ScriptRunnerFactory$RunnerType')
         def testSuiteRunnerClass = cl.loadClass('de.undercouch.citeproc.TestSuiteRunner')

--- a/citeproc-java/build.gradle
+++ b/citeproc-java/build.gradle
@@ -126,7 +126,7 @@ task extractCiteprocZip(type: Copy, dependsOn: downloadCiteprocZip) {
 
 task extractTestSuite(type: Copy, dependsOn: [ downloadTestSuite, extractCiteprocZip ]) {
     from zipTree(file(downloadTestSuite.dest))
-    into new File(buildDir, "test-suite/extracted/tests/fixtures/std")
+    into new File(buildDir, "test-suite/extracted/fixtures/std")
     eachFile { fcp ->
         // strip off first directory
         fcp.relativePath = new RelativePath(!fcp.file.isDirectory(),


### PR DESCRIPTION
to process fixtures.

Fixes https://github.com/michel-kraemer/citeproc-java/issues/60