### PR TITLE
only create links for trusted href values

### DIFF
--- a/citeproc-java/src/main/java/de/undercouch/citeproc/csl/internal/format/HtmlFormat.java
+++ b/citeproc-java/src/main/java/de/undercouch/citeproc/csl/internal/format/HtmlFormat.java
@@ -10,6 +10,7 @@ import de.undercouch.citeproc.output.SecondFieldAlign;
 import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.List;
+import java.util.Locale;
 
 import static de.undercouch.citeproc.csl.internal.behavior.FormattingAttributes.FS_ITALIC;
 import static de.undercouch.citeproc.csl.internal.behavior.FormattingAttributes.FW_BOLD;
@@ -58,7 +59,13 @@ public class HtmlFormat extends BaseFormat {
 
     @Override
     protected String doFormatLink(String text, String uri) {
-        return "<a href=\"" + uri + "\">" + text + "</a>";
+        String uriLowerCase = uri.toLowerCase(Locale.ENGLISH);
+        if (uriLowerCase.startsWith("http://")
+                || uriLowerCase.startsWith("https://")
+                || uriLowerCase.startsWith("/")) {
+            return "<a href=\"" + uri + "\">" + text + "</a>";
+        }
+        return text;
     }
 
     @Override


### PR DESCRIPTION
At the moment, a url value of `javascript:alert(document.domain)` is converted to
`<a href="javascript:alert(document.domain)">javascript:alert(document.domain)</a>`.

I belief the risk is very low because the javascript code is clearly visible. But it might be a good idea to fix this issue anyway.

Steps to reproduce:

```java
    public static void main(String[] args) throws IOException {
        CSLItemData item = new CSLItemDataBuilder()
            .type(CSLType.ARTICLE_JOURNAL)
            .title("Protein measurement with the Folin phenol reagent")
            .author(
                new CSLNameBuilder().given("G").family("Krüger").build()
            )
            .URL("javascript:alert(document.domain)")
            .build();

        ItemDataProvider provider = new ListItemDataProvider(item);
        CSL csl = new CSL(provider, "ieee-with-url");
        csl.registerCitationItems(item.getId());
        csl.setConvertLinks(true);
        csl.setOutputFormat("html");

        String res = csl.makeBibliography().makeString();
        System.out.println(res);
    }
```