### PR TITLE
treat empty arrays as undefined variables (regression)

### DIFF
--- a/citeproc-java/src/main/java/de/undercouch/citeproc/csl/internal/rendering/SLabel.java
+++ b/citeproc-java/src/main/java/de/undercouch/citeproc/csl/internal/rendering/SLabel.java
@@ -79,6 +79,9 @@ public class SLabel implements SRenderingElement {
         if (value == null) {
             return;
         }
+        if (value instanceof Object[] && ((Object[]) value).length == 0) {
+            return;
+        }
 
         String term = variable;
         boolean plural = false;


### PR DESCRIPTION
The JavaScript implementation treats empty arrays non-existing information. But the Java implementation only checked for null references.

For example, a paper may have authors but no editors. If the editor array is null, everything works fine. But if editor is set to an empty array, the text "eds" is added to the output by many styles.