### PR TITLE
Fix IndexOutOfBoundsException in FoFormat and AsciiDocFormat if CSL item is empty

### DIFF
--- a/citeproc-java/src/main/java/de/undercouch/citeproc/csl/internal/format/AsciiDocFormat.java
+++ b/citeproc-java/src/main/java/de/undercouch/citeproc/csl/internal/format/AsciiDocFormat.java
@@ -3,8 +3,11 @@ package de.undercouch.citeproc.csl.internal.format;
 import de.undercouch.citeproc.csl.internal.RenderContext;
 import de.undercouch.citeproc.csl.internal.SBibliography;
 import de.undercouch.citeproc.csl.internal.TokenBuffer;
+import de.undercouch.citeproc.csl.internal.token.Token;
 import de.undercouch.citeproc.output.Bibliography;
 import de.undercouch.citeproc.output.SecondFieldAlign;
+
+import java.util.List;
 
 import static de.undercouch.citeproc.csl.internal.behavior.FormattingAttributes.FW_BOLD;
 import static de.undercouch.citeproc.csl.internal.behavior.FormattingAttributes.VA_SUP;
@@ -40,11 +43,12 @@ public class AsciiDocFormat extends BaseFormat {
         if (sfa != SecondFieldAlign.FALSE && !buffer.getTokens().isEmpty()) {
             // find tokens that are part of the first field
             int i = 0;
-            while (buffer.getTokens().get(i).isFirstField()) {
+            List<Token> tokens = buffer.getTokens();
+            while (i < tokens.size() && tokens.get(i).isFirstField()) {
                 ++i;
             }
             TokenBuffer firstBuffer = buffer.copy(0, i);
-            TokenBuffer restBuffer = buffer.copy(i, buffer.getTokens().size());
+            TokenBuffer restBuffer = buffer.copy(i, tokens.size());
 
             // render first field and rest independently
             result = "[.csl-left-margin]##" + format(firstBuffer) +

--- a/citeproc-java/src/main/java/de/undercouch/citeproc/csl/internal/format/FoFormat.java
+++ b/citeproc-java/src/main/java/de/undercouch/citeproc/csl/internal/format/FoFormat.java
@@ -4,9 +4,12 @@ import de.undercouch.citeproc.csl.internal.RenderContext;
 import de.undercouch.citeproc.csl.internal.SBibliography;
 import de.undercouch.citeproc.csl.internal.TokenBuffer;
 import de.undercouch.citeproc.csl.internal.token.DisplayGroupToken;
+import de.undercouch.citeproc.csl.internal.token.Token;
 import de.undercouch.citeproc.output.Bibliography;
 import de.undercouch.citeproc.output.SecondFieldAlign;
 import org.apache.commons.text.StringEscapeUtils;
+
+import java.util.List;
 
 import static de.undercouch.citeproc.csl.internal.behavior.FormattingAttributes.FS_ITALIC;
 import static de.undercouch.citeproc.csl.internal.behavior.FormattingAttributes.FW_BOLD;
@@ -54,11 +57,12 @@ public class FoFormat extends BaseFormat {
         if (sfa != SecondFieldAlign.FALSE && !buffer.getTokens().isEmpty()) {
             // find tokens that are part of the first field
             int i = 0;
-            while (buffer.getTokens().get(i).isFirstField()) {
+            List<Token> tokens = buffer.getTokens();
+            while (i < tokens.size() && tokens.get(i).isFirstField()) {
                 ++i;
             }
             TokenBuffer firstBuffer = buffer.copy(0, i);
-            TokenBuffer restBuffer = buffer.copy(i, buffer.getTokens().size());
+            TokenBuffer restBuffer = buffer.copy(i, tokens.size());
 
             // render first field and rest independently
             result = "\n  <fo:table table-layout=\"fixed\" width=\"100%\">\n    " +

--- a/citeproc-java/src/test/java/de/undercouch/citeproc/CSLTest.java
+++ b/citeproc-java/src/test/java/de/undercouch/citeproc/CSLTest.java
@@ -643,6 +643,67 @@ public class CSLTest {
     }
 
     /**
+     * Check if an empty 'thesis' item can be converted to XSL-FO
+     */
+    @Test
+    public void emptyFo() throws Exception {
+        CSLItemData item = new CSLItemDataBuilder()
+                .id("EMPTY-THESIS")
+                .type(CSLType.THESIS)
+                .build();
+
+        CSL citeproc = new CSL(new ListItemDataProvider(item), "ieee");
+        citeproc.setOutputFormat("fo");
+        citeproc.makeCitation(item.getId());
+
+        Bibliography b = citeproc.makeBibliography();
+
+        assertEquals(1, b.getEntries().length);
+        assertEquals(
+                "<fo:block id=\"EMPTY-THESIS\">\n" +
+                "  <fo:table table-layout=\"fixed\" width=\"100%\">\n" +
+                "    <fo:table-column column-number=\"1\" column-width=\"2.5em\"/>\n" +
+                "    <fo:table-column column-number=\"2\" column-width=\"proportional-column-width(1)\"/>\n" +
+                "    <fo:table-body>\n" +
+                "      <fo:table-row>\n" +
+                "        <fo:table-cell>\n" +
+                "          <fo:block>[1]</fo:block>\n" +
+                "        </fo:table-cell>\n" +
+                "        <fo:table-cell>\n" +
+                "          <fo:block></fo:block>\n" +
+                "        </fo:table-cell>\n" +
+                "      </fo:table-row>\n" +
+                "    </fo:table-body>\n" +
+                "  </fo:table>\n" +
+                "</fo:block>\n",
+                b.getEntries()[0]
+        );
+    }
+
+    /**
+     * Check if an empty 'thesis' item can be converted to AsciiDoc
+     */
+    @Test
+    public void emptyAsciiDoc() throws Exception {
+        CSLItemData item = new CSLItemDataBuilder()
+                .type(CSLType.THESIS)
+                .build();
+
+        CSL citeproc = new CSL(new ListItemDataProvider(item), "ieee");
+        citeproc.setOutputFormat("asciidoc");
+        citeproc.makeCitation(item.getId());
+
+        Bibliography b = citeproc.makeBibliography();
+
+        assertEquals(1, b.getEntries().length);
+        assertEquals(
+                "[.csl-entry]\n" +
+                "[.csl-left-margin]##[1]##[.csl-right-inline]####\n",
+                b.getEntries()[0]
+        );
+    }
+
+    /**
      * Test if parsing a style with multiple if nodes within a choose node
      * throws an exception
      * @throws Exception if the test succeeds


### PR DESCRIPTION
The XLS-FO- and AsciiDoc-Formats have the same issue the HTML-Format had, that was described in michel-kraemer/citeproc-java#206.
I adapted the solution from michel-kraemer/citeproc-java@ba0464813ee007db862e860ade159776bbe68b9f and added tests based on the test implemented in the same commit.