### PR TITLE
Fix handling of enclosing braces in `NameParser`

### DIFF
--- a/citeproc-java/src/main/java/de/undercouch/citeproc/bibtex/NameParser.java
+++ b/citeproc-java/src/main/java/de/undercouch/citeproc/bibtex/NameParser.java
@@ -9,21 +9,44 @@ import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * Parses a human's name to a {@link CSLName} object
  * @author Michel Kraemer
  */
 public class NameParser {
     /**
+     * Pattern to match braced content in names
+     */
+    private static final Pattern BRACED_CONTENT_PATTERN = Pattern.compile("\\{([^{}]*)\\}");
+
+    /**
+     * Pattern to match "and" separators between names
+     */
+    private static final Pattern AND_SEPARATOR_PATTERN = Pattern.compile("\\s+and\\s+", Pattern.CASE_INSENSITIVE);
+
+    /**
      * Parses names to {@link CSLName} objects. Also handles strings
      * containing multiple names separated by {@code and}. The
      * method always returns at least one object, even if the given
      * names cannot be parsed. In this case the returned object just
      * contains a literal string.
+     * <p>
+     * Special handling is provided for names enclosed in braces {},
+     * which are meant to be preserved as-is in the output.
+     *
      * @param names the names to parse
      * @return the {@link CSLName} objects (never {@code null} and never empty)
      */
     public static CSLName[] parse(String names) {
+        if (names.contains("{")) {
+            return parseWithBraces(names);
+        }
+
         CharStream cs = CharStreams.fromString(names);
         InternalNameLexer lexer = new InternalNameLexer(cs);
         lexer.removeErrorListeners(); // do not output errors to console
@@ -37,5 +60,33 @@ public class NameParser {
             return new CSLName[] { new CSLNameBuilder().literal(names).build() };
         }
         return ctx.result.toArray(new CSLName[0]);
+    }
+
+    private static CSLName[] parseWithBraces(String names) {
+        // for mixed corporate and normal authors
+        // e.g. author = {John Smith and {Corporation Name} and Jane Doe}
+        String[] nameParts = AND_SEPARATOR_PATTERN.split(names);
+        List<CSLName> result = new ArrayList<>();
+
+        for (String namePart : nameParts) {
+            namePart = namePart.trim();
+
+            Matcher matcher = BRACED_CONTENT_PATTERN.matcher(namePart);
+
+            if (matcher.find()) {
+                String bracedContent = matcher.group(1);
+
+                result.add(new CSLNameBuilder().literal(bracedContent).build());
+            } else {
+                CSLName[] parsed = parse(namePart);
+                if (parsed.length > 0) {
+                    result.add(parsed[0]);
+                }
+            }
+        }
+
+        return result.isEmpty() ?
+                new CSLName[] { new CSLNameBuilder().literal(names).build() } :
+                result.toArray(new CSLName[0]);
     }
 }

--- a/citeproc-java/src/test/java/de/undercouch/citeproc/bibtex/NameParserTest.java
+++ b/citeproc-java/src/test/java/de/undercouch/citeproc/bibtex/NameParserTest.java
@@ -4,6 +4,7 @@ import de.undercouch.citeproc.csl.CSLName;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests the name parser
@@ -227,5 +228,55 @@ public class NameParserTest {
         CSLName[] names = NameParser.parse(str);
         assertEquals(1, names.length);
         assertEquals(str, names[0].getLiteral());
+    }
+
+    /**
+     * Tests if a name enclosed in braces is preserved as-is
+     */
+    @Test
+    public void bracedNamePreserved() {
+        CSLName[] names = NameParser.parse("{John Doe}");
+        assertEquals(1, names.length);
+        assertEquals("John Doe", names[0].getLiteral());
+
+        // these should be null since we're using literal
+        assertNull(names[0].getFamily());
+        assertNull(names[0].getGiven());
+    }
+
+    /**
+     * Tests if multiple braced names are handled correctly
+     */
+    @Test
+    public void multipleBracedNames() {
+        CSLName[] names = NameParser.parse("{John Doe} and {Jane Smith}");
+        assertEquals(2, names.length);
+        assertEquals("John Doe", names[0].getLiteral());
+        assertEquals("Jane Smith", names[1].getLiteral());
+    }
+
+    /**
+     * Tests mixed braced and non-braced names
+     */
+    @Test
+    public void mixedBracedAndNonBraced() {
+        CSLName[] names = NameParser.parse("{John Doe} and Jane Smith");
+        assertEquals(2, names.length);
+        assertEquals("John Doe", names[0].getLiteral());
+        assertEquals("Jane", names[1].getGiven());
+        assertEquals("Smith", names[1].getFamily());
+    }
+
+    /**
+     * Tests non-braced name with van particle
+     */
+    @Test
+    public void nonBracedWithParticle() {
+        CSLName[] names = NameParser.parse("{Ludwig van Beethoven} and Vincent van Gogh");
+        assertEquals(2, names.length);
+        assertEquals("Ludwig van Beethoven", names[0].getLiteral());
+        assertEquals("Vincent", names[1].getGiven());
+        assertEquals("van", names[1].getNonDroppingParticle());
+        assertEquals("Gogh", names[1].getFamily());
     }
 }

--- a/citeproc-java/src/test/java/de/undercouch/citeproc/bibtex/NameParserTest.java
+++ b/citeproc-java/src/test/java/de/undercouch/citeproc/bibtex/NameParserTest.java
@@ -279,4 +279,19 @@ public class NameParserTest {
         assertEquals("van", names[1].getNonDroppingParticle());
         assertEquals("Gogh", names[1].getFamily());
     }
+
+    /**
+     * Tests that "and" inside braces is preserved as part of the name
+     * and not treated as a separator
+     */
+    @Test
+    public void andInsideBraces() {
+        CSLName[] names = NameParser.parse("{Barnes and Noble, Inc.}");
+        assertEquals(1, names.length);
+        assertEquals("Barnes and Noble, Inc.", names[0].getLiteral());
+
+        // the name should not be parsed as separate components
+        assertNull(names[0].getFamily());
+        assertNull(names[0].getGiven());
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/michel-kraemer/citeproc-java/issues/103

Hi @michel-kraemer! I am a @JabRef developer. We use citeproc-java in our CSL preview viewer as well as our LibreOffice/OpenOffice integration. Huge thanks for your work that makes rendering CSL citations in Java-based apps seamless.

This is an issue we noticed (when using the [preview viewer](https://github.com/JabRef/jabref/issues/12930) and [LO](https://github.com/JabRef/jabref/issues/12959)), so thought of taking a dive at at it.

I am not aware if I am supposed to follow any specific style, so apologies if I missed something.
Would appreciate your feedback!