### PR TITLE
Readd curly braces in author names after latex parsing

### DIFF
--- a/citeproc-java/src/main/java/de/undercouch/citeproc/bibtex/BibTeXConverter.java
+++ b/citeproc-java/src/main/java/de/undercouch/citeproc/bibtex/BibTeXConverter.java
@@ -21,10 +21,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * <p>Converts BibTeX items to CSL citation items</p>
@@ -116,6 +113,107 @@ public class BibTeXConverter {
     }
 
     /**
+     * Re-add curly braces around parts of a name string that were enclosed in curly
+     * braces in the original BibTeX field. This is necessary because the LaTeX conversion
+     * removes braces, but NameParser uses them to detect literal names.
+     * Only applies to author/editor fields.
+     * @param original the original field value (possibly containing braces and LaTeX)
+     * @param converted the field value after LaTeX conversion
+     * @return the converted string with curly braces re-added where appropriate
+     */
+    private String reAddCurlyBracesInNames(String original, String converted) {
+        if (original == null || converted == null || original.indexOf('{') < 0) {
+            return converted;
+        }
+
+        int len = original.length();
+        // Collect all top-level brace segments (and nested ones), but skip one that
+        // wraps the whole string
+        List<int[]> segments = new ArrayList<>();
+        int depth = 0;
+        int segStart = -1;
+        for (int i = 0; i < len; ++i) {
+            char c = original.charAt(i);
+            if (c == '{') {
+                depth++;
+                if (depth == 1) {
+                    segStart = i;
+                }
+            } else if (c == '}') {
+                if (depth == 1) {
+                    // candidate segment from segStart to i
+                    // skip if it covers the whole string
+                    if (!(segStart == 0 && i == len - 1)) {
+                        segments.add(new int[] { segStart, i });
+                    }
+                    segStart = -1;
+                }
+                if (depth > 0) {
+                    depth--;
+                }
+            }
+        }
+
+        if (segments.isEmpty()) {
+            return converted;
+        }
+
+        String result = converted;
+        for (int[] seg : segments) {
+            int start = seg[0] + 1; // content inside braces
+            int end = seg[1];
+            if (start >= end) {
+                continue;
+            }
+            // Convert the inner LaTeX to the same plain text to find in converted
+            String innerConverted = original.substring(start, end);
+            try {
+                java.util.List<LaTeXObject> objs = latexParser.parse(new StringReader(innerConverted));
+                innerConverted = latexPrinter.print(objs).replaceAll("\\n", " ").replaceAll("\\r", "").trim();
+            } catch (Exception ex) {
+                // ignore parse errors; fall back to raw inner
+            }
+            if (innerConverted.isEmpty()) {
+                continue;
+            }
+            result = wrapWithBracesIfFound(result, innerConverted);
+        }
+        return result;
+    }
+
+    private String wrapWithBracesIfFound(String text, String needle) {
+        int fromIndex = 0;
+        StringBuilder sb = new StringBuilder();
+        while (fromIndex < text.length()) {
+            int idx = text.indexOf(needle, fromIndex);
+            if (idx < 0) {
+                sb.append(text, fromIndex, text.length());
+                break;
+            }
+            // Check if already wrapped with braces (ignoring spaces around)
+            int left = idx - 1;
+            while (left >= fromIndex && Character.isWhitespace(text.charAt(left))) {
+                left--;
+            }
+            int right = idx + needle.length();
+            int r = right;
+            while (r < text.length() && Character.isWhitespace(text.charAt(r))) {
+                r++;
+            }
+            boolean alreadyWrapped = left >= 0 && text.charAt(left) == '{' && r < text.length() && text.charAt(r) == '}';
+            sb.append(text, fromIndex, idx);
+            if (alreadyWrapped) {
+                // keep as-is
+                sb.append(text, idx, right);
+            } else {
+                sb.append('{').append(needle).append('}');
+            }
+            fromIndex = right;
+        }
+        return sb.toString();
+    }
+
+    /**
      * <p>Loads a BibTeX database from a stream.</p>
      * <p>This method does not close the given stream. The caller is
      * responsible for closing it.</p>
@@ -161,7 +259,8 @@ public class BibTeXConverter {
         // get all fields from the BibTeX entry
         Map<String, String> entries = new HashMap<>();
         for (Map.Entry<Key, Value> field : e.getFields().entrySet()) {
-            String us = field.getValue().toUserString().replaceAll("\\r", "");
+            String original = field.getValue().toUserString().replaceAll("\\r", "");
+            String us = original;
 
             // convert LaTeX string to normal text
             try {
@@ -171,7 +270,12 @@ public class BibTeXConverter {
                 // ignore
             }
 
-            entries.put(field.getKey().getValue().toLowerCase(), us);
+            String keyLower = field.getKey().getValue().toLowerCase();
+            if (FIELD_AUTHOR.equals(keyLower) || FIELD_EDITOR.equals(keyLower)) {
+                us = reAddCurlyBracesInNames(original, us);
+            }
+
+            entries.put(keyLower, us);
         }
 
         // map type
@@ -200,7 +304,7 @@ public class BibTeXConverter {
             builder.collectionEditor(NameParser.parse(entries.get(FIELD_EDITOR)));
         }
 
-        // map date
+        // map date‚
         CSLDate date;
         if (entries.containsKey(FIELD_DATE)) {
             date = DateParser.toDate(entries.get(FIELD_DATE));

--- a/citeproc-java/src/test/java/de/undercouch/citeproc/bibtex/NameParserTest.java
+++ b/citeproc-java/src/test/java/de/undercouch/citeproc/bibtex/NameParserTest.java
@@ -1,6 +1,8 @@
 package de.undercouch.citeproc.bibtex;
 
 import de.undercouch.citeproc.csl.CSLName;
+import org.jbibtex.BibTeXEntry;
+import org.jbibtex.DigitStringValue;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
Fixes #292  

The reason is that LatexParser in jbibtex uses the curly braces for group indication in the grammar and does not treat it as single item,
