### PR TITLE
fix: Add "language" case to RenderContext switch + unit test

### DIFF
--- a/citeproc-java/src/main/java/de/undercouch/citeproc/csl/internal/RenderContext.java
+++ b/citeproc-java/src/main/java/de/undercouch/citeproc/csl/internal/RenderContext.java
@@ -425,6 +425,9 @@ public class RenderContext {
                 case "keyword":
                     result = itemData.getKeyword();
                     break;
+                case "language":
+                    result = itemData.getLanguage();
+                    break;
                 case "locator":
                     result = itemData.getLocator();
                     break;

--- a/citeproc-java/src/test/resources/fixtures/bibliography-language.yaml
+++ b/citeproc-java/src/test/resources/fixtures/bibliography-language.yaml
@@ -1,0 +1,45 @@
+mode: bibliography
+
+# Minimal style, adapted from the official "BibTeX generic citation style"
+# (https://github.com/citation-style-language/styles/blob/master/bibtex.csl),
+# just to test the language variable
+style:
+    <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0">
+      <macro name="zotero2bibtexType">
+        <choose>
+          <if type="article article-journal article-magazine article-newspaper"
+          match="any">
+            <text value="article"/>
+          </if>
+          <else>
+            <text value="misc"/>
+          </else>
+        </choose>
+      </macro>
+      <bibliography>
+        <layout>
+          <text macro="zotero2bibtexType" prefix=" @"/>
+          <group prefix="{" suffix=" }" delimiter=", ">
+            <text variable="citation-key"/>
+            <text variable="title" prefix=" title={" suffix="}"/>
+            <text variable="language" prefix=" language={" suffix="}"/>
+          </group>
+        </layout>
+      </bibliography>
+    </style>
+
+items:
+    - id: item1
+      type: article-journal
+      citation-key: test_case_1
+      title: An item with a language
+      language: en
+    - id: item2
+      type: article-journal
+      citation-key: test_case_2
+      title: An item without a language
+
+result:
+    text: |2
+       @article{test_case_1, title={An item with a language}, language={en} }
+       @article{test_case_2, title={An item without a language} }


### PR DESCRIPTION
This variable is expected by several CSL formats including `bibtex.csl`, and it was supported in the earlier citeproc-js implementations (e.g. 1.0.1)

Currently, RenderContext checks `itemData.getLanguage()` for locale handling, but does not consider it as a variable in item input data, so it can't be referenced by the stylesheets.

A minimal unit test is included to prove bibtex.csl now includes language.