### PR TITLE
Apply `cs:layout` affixes inside the scope of the layout's formatting attributes

### DIFF
--- a/citeproc-java/src/main/java/de/undercouch/citeproc/csl/internal/SCitationLayout.java
+++ b/citeproc-java/src/main/java/de/undercouch/citeproc/csl/internal/SCitationLayout.java
@@ -40,10 +40,6 @@ public class SCitationLayout extends SRenderingElementContainerElement {
 
     @Override
     public void render(RenderContext ctx) {
-        affixes.wrap(this::renderInternal).accept(ctx);
-    }
-
-    private void renderInternal(RenderContext ctx) {
         RenderContext tmp = new RenderContext(ctx);
         for (CSLCitationItem item : ctx.getCitation().getCitationItems()) {
             RenderContext innerTmp = new RenderContext(ctx, item);
@@ -72,7 +68,18 @@ public class SCitationLayout extends SRenderingElementContainerElement {
                 tmp.emit(suffix, SUFFIX);
             }
         }
-        ctx.emit(tmp.getResult(), formattingAttributes);
+        TokenBuffer buffer = tmp.getResult();
+        if (buffer.isEmpty()) {
+            return;
+        }
+
+        // In contrast to all other elements, affixes on cs:layout are within
+        // the scope of the formatting attributes set on the same element.
+        // Apply them before the formatting attributes are wrapped around the
+        // rendered tokens.
+        affixes.applyTo(buffer);
+
+        ctx.emit(buffer, formattingAttributes);
     }
 
     /**

--- a/citeproc-java/src/main/java/de/undercouch/citeproc/csl/internal/SLayout.java
+++ b/citeproc-java/src/main/java/de/undercouch/citeproc/csl/internal/SLayout.java
@@ -28,10 +28,6 @@ public class SLayout extends SRenderingElementContainerElement {
 
     @Override
     public void render(RenderContext ctx) {
-        affixes.wrap(this::renderInternal).accept(ctx);
-    }
-
-    private void renderInternal(RenderContext ctx) {
         RenderContext tmp = new RenderContext(ctx);
         List<SRenderingElement> elements = getElements(ctx);
         for (int i = 0; i < elements.size(); i++) {
@@ -48,6 +44,24 @@ public class SLayout extends SRenderingElementContainerElement {
                 e.render(tmp);
             }
         }
-        ctx.emit(tmp.getResult(), formattingAttributes);
+        TokenBuffer buffer = tmp.getResult();
+        if (buffer.isEmpty()) {
+            return;
+        }
+
+        // In contrast to all other elements, affixes on cs:layout are within
+        // the scope of the formatting attributes set on the same element.
+        // Apply them before the formatting attributes are wrapped around the
+        // rendered tokens.
+        boolean firstField = buffer.getTokens().get(0).isFirstField();
+        affixes.applyTo(buffer);
+        if (firstField) {
+            // the prefix has been prepended to the first field, so it needs to
+            // be marked as such too (otherwise second-field-align would break)
+            List<Token> tokens = buffer.getTokens();
+            tokens.set(0, tokens.get(0).copyWithFirstField(true));
+        }
+
+        ctx.emit(buffer, formattingAttributes);
     }
 }

--- a/citeproc-java/src/test/resources/fixtures/bibliography-layout-affixes-formatting.yaml
+++ b/citeproc-java/src/test/resources/fixtures/bibliography-layout-affixes-formatting.yaml
@@ -1,0 +1,23 @@
+mode: bibliography
+
+style:
+  <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0">
+    <bibliography>
+      <layout vertical-align="sup" prefix="[" suffix="]">
+        <text variable="title"/>
+      </layout>
+    </bibliography>
+  </style>
+
+items:
+  - id: item1
+    title: My title
+  - id: item2
+    title: Another title
+
+result:
+  html: |-
+    <div class="csl-bib-body">
+      <div class="csl-entry"><sup>[My title]</sup></div>
+      <div class="csl-entry"><sup>[Another title]</sup></div>
+    </div>

--- a/citeproc-java/src/test/resources/fixtures/citation-layout-affixes-formatting.yaml
+++ b/citeproc-java/src/test/resources/fixtures/citation-layout-affixes-formatting.yaml
@@ -1,0 +1,25 @@
+mode: citation
+
+style:
+  <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0">
+    <citation>
+      <layout delimiter="," vertical-align="sup" prefix="[" suffix="]">
+        <text variable="citation-number"/>
+      </layout>
+    </citation>
+  </style>
+
+items:
+  - id: item1
+    author:
+      - given: Given
+        family: Name
+    title: My title
+  - id: item2
+    author:
+      - given: Another
+        family: Name
+
+result:
+  html:
+    <sup>[1,2]</sup>

--- a/citeproc-java/src/test/resources/fixtures/citation-non-layout-affixes-formatting.yaml
+++ b/citeproc-java/src/test/resources/fixtures/citation-non-layout-affixes-formatting.yaml
@@ -1,0 +1,25 @@
+mode: citation
+
+style:
+  <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0">
+    <citation>
+      <layout delimiter=",">
+        <text variable="citation-number" vertical-align="sup" prefix="[" suffix="]"/>
+      </layout>
+    </citation>
+  </style>
+
+items:
+  - id: item1
+    author:
+      - given: Given
+        family: Name
+    title: My title
+  - id: item2
+    author:
+      - given: Another
+        family: Name
+
+result:
+  html: |-
+    [<sup>1</sup>],[<sup>2</sup>]


### PR DESCRIPTION
## Issue
For the style [Advanced Functional Materials](https://github.com/citation-style-language/styles/blob/master/advanced-functional-materials.csl), our (JabRef's) LibreOffice integration was outputting citations with the superscript applied only to the number, and not the surrounding brackets:
<img width="203" height="141" alt="image" src="https://github.com/user-attachments/assets/89a6ebee-88f9-4092-9139-7f1cac61776f" />

This issue didn't exist in case of Zotero, which uses citeproc-js:
<img width="1179" height="245" alt="image" src="https://github.com/user-attachments/assets/f0738eb0-6488-4ddb-ba63-f4e499649c2a" />


On reviewing some logs, it turned out that citeproc-java was indeed emitting the `<sup>` inside the brackets, around the numbers.

(The following analysis has been written with the help of Claude Opus 5, and reviewed/edited by me).

## Cause/Analysis
 
Affixes on `cs:layout` are currently rendered outside the formatting attributes set on the same element. For a numeric style that superscripts its citations, only the number is raised and the brackets stay on the baseline:
 
```xml
<citation>
  <layout delimiter="," vertical-align="sup" prefix="[" suffix="]">
    <text variable="citation-number"/>
  </layout>
</citation>
```
 
| | HTML |
|---|---|
| Current | `[<sup>1</sup>]` |
| Expected | `<sup>[1]</sup>` |
 
Reproducible with [`advanced-functional-materials.csl`](https://github.com/citation-style-language/styles/blob/master/advanced-functional-materials.csl), and with any of the other CSL styles that put affixes and `vertical-align` / `font-style` / `font-weight` on the same layout element.
 
## Why
 
The CSL 1.0.2 spec makes `cs:layout` an explicit exception to the usual affix rule ([spec](https://docs.citationstyles.org/en/stable/specification.html#affixes)):
 
> With the exception of affixes set on cs:layout, affixes are outside the scope of formatting, quotes, strip-periods and text-case attributes set on the same element (as a workaround, these attributes take effect on affixes when set on a parent cs:group element).
 
So for every element *except* layout, the current nesting is right.
 
`SLayout` and `SCitationLayout` don't implement the exception - they use the same `affixes.wrap(this::renderInternal)` pattern as `SGroup`:
 
```java
public void render(RenderContext ctx) {
    affixes.wrap(this::renderInternal).accept(ctx);   // affixes on the outside
}
 
private void renderInternal(RenderContext ctx) {
    ...
    ctx.emit(tmp.getResult(), formattingAttributes);  // formatting on the inside
}
```
 
`Affixes.accept` emits the prefix and suffix into the *parent* context via `emit(String, Type)`, which never goes through `wrapFormattingAttributes(...)`. Only the buffer returned by `renderInternal` is wrapped, so `HtmlFormat` opens `<sup>` around the number alone.
 
## Fix
 
Both layout classes now apply their affixes to the token buffer *before* emitting it with the formatting attributes, using the existing `Affixes.applyTo(TokenBuffer)` (previously only used by `SName`). `SGroup` and the rendering elements are untouched - their behaviour is already correct.
 
`SLayout` additionally re-marks the first token after `applyTo`, so that a layout prefix stays part of the first field and `second-field-align` keeps working.
 
## Tests
 
Three new fixtures:
 
- `citation-layout-affixes-formatting.yaml` - the case above; fails on master
- `bibliography-layout-affixes-formatting.yaml` - same on the bibliography side; fails on master
- `citation-non-layout-affixes-formatting.yaml` - affixes on `cs:text` must stay *outside* its formatting (`[<sup>1</sup>]`); passes before and after, and guards against widening the exception beyond `cs:layout`

I've run the tests, and everything existing passes successfully (along with these).